### PR TITLE
Print catalog session properties on a new line

### DIFF
--- a/presto-main/src/main/resources/webapp/assets/query.js
+++ b/presto-main/src/main/resources/webapp/assets/query.js
@@ -858,7 +858,7 @@ let QueryDetail = React.createClass({
                 for (let property in query.session.catalogProperties[catalog]) {
                     if (query.session.catalogProperties[catalog].hasOwnProperty(property)) {
                         properties.push(
-                            <span>- { catalog + "." + property + "=" + query.session.catalogProperties[catalog][property] } </span>
+                            <span>- { catalog + "." + property + "=" + query.session.catalogProperties[catalog][property] } <br /></span>
                         );
                     }
                 }


### PR DESCRIPTION
I think there's a formatting typo here in printing catalog session properties. Like system session properties each of these need to be on a new line.